### PR TITLE
Add 'all' as completion candidates of 'clean' subcommand in nodebrew-completion

### DIFF
--- a/completions/bash/nodebrew-completion
+++ b/completions/bash/nodebrew-completion
@@ -3,39 +3,38 @@
 _nodebrew()
 {
     local opts cur prev
-    opts="alias unalias ls ls-all ls-remote list install use clean selfupdate uninstall help"
+    opts="alias unalias ls ls-all ls-remote list install uninstall  use clean selfupdate  help"
     cur="${COMP_WORDS[COMP_CWORD]}"
     prev="${COMP_WORDS[COMP_CWORD-1]}"
 
     if [ $COMP_CWORD = 1 ]; then
-        COMPREPLY=( $( compgen -W "${opts}" ${cur} ) )
-        return 0
-    elif [ $COMP_CWORD > 1 ];then
-        local _alias _versions
 
+        COMPREPLY=( $( compgen -W "${opts}" ${cur} ) )
+    elif [ $COMP_CWORD = 2 ];then
+        local _alias _versions
         _versions=$(nodebrew ls 2> /dev/null | grep '^v')
         _alias=$(nodebrew alias 2> /dev/null | sed 's/->.*//')
 
         case "${prev}" in
             use)
-                local _target
-                _target="${_versions} ${_alias}"
-                COMPREPLY=( $(compgen -W "${_target}" ${cur} ) )
-                return 0
+                local target
+                target="${_versions} ${_alias}"
+                COMPREPLY=( $(compgen -W "${target}" ${cur} ) )
             ;;
             install)
                 local _remote_versions
                 _remote_versions=$(nodebrew ls-remote 2> /dev/null)
                 COMPREPLY=( $(compgen -W "${_remote_versions}" ${cur} ) )
-                return 0
             ;;
-            clean|uninstall)
+            clean)
+                _versions="${_versions} all"
                 COMPREPLY=( $(compgen -W "${_versions}" ${cur} ) )
-                return 0
+            ;;
+            uninstall)
+                COMPREPLY=( $(compgen -W "${_versions}" ${cur} ) )
             ;;
             alias|unalias)
                 COMPREPLY=( $(compgen -W "${_alias}" ${cur} ) )
-                return 0
             ;;
         esac
     fi


### PR DESCRIPTION
[Bugfix] Add 'all' as completion candidates of 'clean' subcommand in nodebrew-completion.
