### PR TITLE
Fix migrate-package

### DIFF
--- a/nodebrew
+++ b/nodebrew
@@ -317,7 +317,7 @@ sub _cmd_migrate_package {
     my $is_iojs = $current_version =~ s/^io@//;
     error_and_exit("version not selected") if $current_version eq 'none';
 
-    my $current_type = $current_version =~ $is_iojs ? 'iojs' : 'node';
+    my $current_type = $is_iojs ? 'iojs' : 'node';
     my @current_packages = $self->get_packages($current_version, $current_type);
 
     my $version = $self->find_available_version($args->[0]);


### PR DESCRIPTION
```
/tmp/nodebrew% perl -de 1

Loading DB routines from perl5db.pl version 1.33
Editor support available.

Enter h or `h h' for help, or `man perldebug' for more help.

main::(-e:1):	1
  DB<1> $current_version = 'io@v2.3.0'

  DB<2> p $current_version
io@v2.3.0
  DB<3> $is_iojs = $current_version =~ s/^io@//

  DB<4> p $is_iojs
1
  DB<5> p ($current_version =~ $is_iojs)

  DB<6> p ($current_version =~ $is_iojs ? 'iojs' : 'node')
node
  DB<7> p ('v2.1.0' =~ $is_iojs ? 'iojs' : 'node')
iojs
  DB<8>
  ```

results of `$current_version =~ $is_iojs` will become to false If it does not include `1` to $current_version
So, I remove `$current_version =~ `

Is this patch correct?
