### PR TITLE
show versions more compactly

### DIFF
--- a/nodebrew
+++ b/nodebrew
@@ -205,7 +205,11 @@ sub _cmd_ls_remote {
 
     for (@versions) {
         my ($v1, $v2, $v3) = $_ =~ m/v(\d+)\.(\d+)\.(\d+)/;
-        if (!$tmp{"$v1.$v2"}++) {
+        if ($v1 == 0 && !$tmp{"$v1.$v2"}++) {
+            print "\n\n" if $i;
+            $i = 0;
+        }
+        elsif ($v1 != 0 && !$tmp{"$v1"}++) {
             print "\n\n" if $i;
             $i = 0;
         }


### PR DESCRIPTION
Before:

```
...
v4.0.0

v4.1.0    v4.1.1    v4.1.2

v4.2.0    v4.2.1    v4.2.2    v4.2.3

v5.0.0

v5.1.0    v5.1.1

v5.2.0

io@v1.0.0 io@v1.0.1 io@v1.0.2 io@v1.0.3 io@v1.0.4

io@v1.1.0

io@v1.2.0

io@v1.3.0

io@v1.4.1 io@v1.4.2 io@v1.4.3

io@v1.5.0 io@v1.5.1

io@v1.6.0 io@v1.6.1 io@v1.6.2 io@v1.6.3 io@v1.6.4

io@v1.7.1

io@v1.8.1 io@v1.8.2 io@v1.8.3 io@v1.8.4
```

After:

```
...

v4.0.0    v4.1.0    v4.1.1    v4.1.2    v4.2.0    v4.2.1    v4.2.2    v4.2.3


v5.0.0    v5.1.0    v5.1.1    v5.2.0

io@v1.0.0 io@v1.0.1 io@v1.0.2 io@v1.0.3 io@v1.0.4 io@v1.1.0 io@v1.2.0 io@v1.3.0
io@v1.4.1 io@v1.4.2 io@v1.4.3 io@v1.5.0 io@v1.5.1 io@v1.6.0 io@v1.6.1 io@v1.6.2
io@v1.6.3 io@v1.6.4 io@v1.7.1 io@v1.8.1 io@v1.8.2 io@v1.8.3 io@v1.8.4
```