### PR TITLE
Escaped left brace in regex

### DIFF
--- a/nodebrew
+++ b/nodebrew
@@ -732,7 +732,7 @@ sub apply_vars {
     for my $key (keys %$hash) {
         my $val = $hash->{$key};
 
-        $str =~ s/#{$key}/$val/g;
+        $str =~ s/#\{$key\}/$val/g;
     }
 
     return $str;


### PR DESCRIPTION
Unescaped left brace in regex is deprecated in Perl 5.22.

- http://perldoc.perl.org/perl5220delta.html#New-Warnings