### PR TITLE
Exec command exit with external command's exit code.

### DIFF
--- a/nodebrew
+++ b/nodebrew
@@ -372,6 +372,7 @@ sub _cmd_exec {
     my $command = join ' ', @$args;
 
     system $command;
+    exit $? >> 8;
 }
 
 sub _cmd_help {


### PR DESCRIPTION
Fix issue exec command always exit 0.