### PR TITLE
Fix #63 - Add checking "HTTP/2 200" for curl

### DIFF
--- a/nodebrew
+++ b/nodebrew
@@ -863,7 +863,7 @@ sub new { bless {}; }
 sub fetch_able {
     my ($self, $url) = @_;
 
-    `curl -LIs "$url"` =~ m/200 OK/;
+    `curl -LIs "$url"` =~ m/200 OK|HTTP\/2 200/;
 }
 
 sub fetch {


### PR DESCRIPTION
fetch_able is currently checking if the response of curl command is
matched to "200 OK" or not.

However, HTTP/2 spec does not define the reason phrase. The HTTP/2
server just returns the status code without reason phrase. See section
8.1.2.4 of HTTP/2 spec for details.

Hence, the current checking mechanism in fetch_able always returns false
with the newer versions of curl which supports HTTP/2.

This causes that install and install-binary commands fail with
"<version> is not found. Can not fetch: ...".