### PR TITLE
Fix wget fetch_able func to work with HTTP2 or 1.1

### DIFF
--- a/nodebrew
+++ b/nodebrew
@@ -893,7 +893,7 @@ sub new { bless {}; }
 sub fetch_able {
     my ($self, $url) = @_;
 
-    `wget -Sq --spider "$url" 2>&1` =~ m/200 OK/;
+    `wget -Sq --spider "$url" 2>&1` =~ m/200 OK|HTTP\/(1.1|2) 200/;
 }
 
 sub fetch {


### PR DESCRIPTION
If an user has installed latest wget binary and try to install, it failed because wget try to use HTTP/2. This commit fixes that like curl does.