### PR TITLE
feat: add `prune` command to remove old versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ List remote versions.
 
 ```bash
 $ nodebrew ls-remote
-v0.0.1    v0.0.2    v0.0.3    v0.0.4    v0.0.5    v0.0.6    
+v0.0.1    v0.0.2    v0.0.3    v0.0.4    v0.0.5    v0.0.6
 ...
 ```
 
@@ -121,7 +121,7 @@ List installed and remote versions.
 ```bash
 $ nodebrew ls-all
 Remote:
-v0.0.1    v0.0.2    v0.0.3    v0.0.4    v0.0.5    v0.0.6    
+v0.0.1    v0.0.2    v0.0.3    v0.0.4    v0.0.5    v0.0.6
 ...
 
 Local:
@@ -190,6 +190,7 @@ $ nodebrew clean <version> | all        Remove source file
 $ nodebrew selfupdate                   Update nodebrew
 $ nodebrew migrate-package <version>    Install global NPM packages contained in <version> to current version
 $ nodebrew exec <version> -- <command>  Execute <command> using specified <version>
+$ nodebrew prune [--dry-run]            Uninstall old versions, keeping the latest version for each major version
 ```
 
 ## Uninstall nodebrew

--- a/nodebrew
+++ b/nodebrew
@@ -441,7 +441,7 @@ Usage:
     nodebrew selfupdate                   Update nodebrew
     nodebrew migrate-package <version>    Install global NPM packages contained in <version> to current version
     nodebrew exec <version> -- <command>  Execute <command> using specified <version>
-    nodebrew prune                        Uninstall old versions, keeping the latest version for each major version
+    nodebrew prune [--dry-run]            Uninstall old versions, keeping the latest version for each major version
 
 Example:
     # install

--- a/nodebrew
+++ b/nodebrew
@@ -194,6 +194,43 @@ sub _cmd_list {
     print "\n\ncurrent: " . $self->get_current_version() . "\n";
 }
 
+sub _cmd_prune {
+    my ($self, $args) = @_;
+
+    my $dry_run = grep { $_ eq '--dry-run' } @$args;
+
+    my @node_versions = @{$self->get_local_version('node')};
+    my @iojs_versions = map { "io\@$_"; } @{$self->get_local_version('iojs')};
+    my @versions;
+    push @versions, @node_versions, @iojs_versions;
+
+    my %major_map;
+    for my $version (@versions) {
+        my($variant, $major) = $version =~ m/([^@]+@)?(v\d+)/;
+        $variant ||= "";
+        push @{$major_map{"$variant$major"} ||= []}, $version;
+    }
+
+    my @keeping;
+    my @removing;
+    for my $major (@{Nodebrew::Utils::sort_version([keys %major_map])}) {
+        my @vers = @{Nodebrew::Utils::sort_version($major_map{$major})};
+        my $latest_ver = pop @vers;
+        push @keeping, $latest_ver;
+        push @removing, @vers;
+
+        print "$major:\n";
+        print "  keeping: $latest_ver\n";
+        print "  removing: [" . join(", ", @vers) . "]\n";
+    }
+
+    if (!$dry_run) {
+        for my $version (@removing) {
+            $self->_cmd_uninstall([$version]);
+        }
+    }
+}
+
 sub _cmd_ls {
     my ($self, $args) = @_;
 
@@ -404,6 +441,7 @@ Usage:
     nodebrew selfupdate                   Update nodebrew
     nodebrew migrate-package <version>    Install global NPM packages contained in <version> to current version
     nodebrew exec <version> -- <command>  Execute <command> using specified <version>
+    nodebrew prune                        Uninstall old versions, keeping the latest version for each major version
 
 Example:
     # install
@@ -673,9 +711,11 @@ sub sort_version {
     my $version = shift;
 
     return [sort {
-        my ($a1, $a2, $a3) = ($a =~ m/v(\d+)\.(\d+)\.(\d+)/);
-        my ($b1, $b2, $b3) = ($b =~ m/v(\d+)\.(\d+)\.(\d+)/);
-        $a1 <=> $b1 || $a2 <=> $b2 || $a3 <=> $b3
+        my ($a0, $a1, $a2, $a3) = ($a =~ m/([^@]+@)?v(\d+)(?:\.(\d+)\.(\d+))?/);
+        my ($b0, $b1, $b2, $b3) = ($b =~ m/([^@]+@)?v(\d+)(?:\.(\d+)\.(\d+))?/);
+        $a0 ||= ""; $a1 ||= 0; $a2 ||= 0; $a3 ||= 0;
+        $b0 ||= ""; $b1 ||= 0; $b2 ||= 0; $b3 ||= 0;
+        $a0 cmp $b0 || $a1 <=> $b1 || $a2 <=> $b2 || $a3 <=> $b3
     } @$version];
 }
 

--- a/t/command_prune.t
+++ b/t/command_prune.t
@@ -1,0 +1,42 @@
+use strict;
+use warnings;
+
+use t::Util;
+use Test::More;
+
+my $nodebrew = init_nodebrew();
+$nodebrew->run('setup');
+$nodebrew->run('install', ['v8.9.0']);
+$nodebrew->run('install', ['v8.9.4']);
+$nodebrew->run('install', ['v6.2.0']);
+$nodebrew->run('install', ['v6.2.1']);
+$nodebrew->run('use', ['v8.9.0']); # not the latest, but should be kept
+
+is $nodebrew->run('prune', ['--dry-run']), <<'EOT';
+v6:
+  keeping: v6.2.1
+  removing: [v6.2.0]
+v8:
+  keeping: v8.9.4
+  removing: [v8.9.0]
+EOT
+
+ok -e "$nodebrew->{node_dir}/v6.2.0", "old version is not uninstalled because --dry-run is set";
+
+is $nodebrew->run('prune'), <<'EOT';
+v6:
+  keeping: v6.2.1
+  removing: [v6.2.0]
+v8:
+  keeping: v8.9.4
+  removing: [v8.9.0]
+v6.2.0 uninstalled
+v8.9.0 uninstalled
+EOT
+
+ok !-e "$nodebrew->{node_dir}/v6.2.0";
+ok -e "$nodebrew->{node_dir}/v6.2.1";
+ok !-e "$nodebrew->{node_dir}/v8.9.0";
+ok -e "$nodebrew->{node_dir}/v8.9.4";
+
+done_testing;


### PR DESCRIPTION
The new `prune` command uninstalls old versions, keeping the latest version for each major release.

For example, given you have `v10.0.0`, `v10.0.1`, `v12.0.0`, and `v12.0.1`, `nodebrew prune` removes `v10.0.0` and `v12.0.0`. 